### PR TITLE
Fix: Make output a dictionary

### DIFF
--- a/src/cap2geojson/__init__.py
+++ b/src/cap2geojson/__init__.py
@@ -23,7 +23,7 @@ import logging
 
 from .convert import to_geojson
 
-__version__ = "0.1.0-dev1"
+__version__ = "0.1.0-dev2"
 
 logging.basicConfig(
     level=logging.INFO,

--- a/src/cap2geojson/__init__.py
+++ b/src/cap2geojson/__init__.py
@@ -32,5 +32,5 @@ logging.basicConfig(
 )
 
 
-def transform(xml: str) -> str:
+def transform(xml: str) -> dict:
     return to_geojson(xml)

--- a/src/cap2geojson/cli.py
+++ b/src/cap2geojson/cli.py
@@ -1,4 +1,5 @@
 import click
+import json
 
 from cap2geojson import __version__, transform as transform_to_geojson
 
@@ -20,7 +21,8 @@ def transform(ctx, cap_xml) -> None:
     filename = cap_xml.name.split(".")[0] + ".geojson"
 
     try:
-        result = transform_to_geojson(cap)
+        output = transform_to_geojson(cap)
+        result = json.dumps(output, indent=2)
         # Write the contents to a file
         with open(filename, "w") as f:
             f.write(result)

--- a/src/cap2geojson/convert.py
+++ b/src/cap2geojson/convert.py
@@ -224,7 +224,8 @@ def to_geojson(xml: str) -> dict:
     }
 
     try:
-        geojson.loads(result)
+        # Verify the GeoJSON is valid
+        geojson.loads(json.dumps(result))
     except Exception as e:
         logger.error(f"Error converting to GeoJSON: {e}")
         raise

--- a/src/cap2geojson/convert.py
+++ b/src/cap2geojson/convert.py
@@ -137,7 +137,9 @@ def get_polygon_coordinates(single_area: dict) -> list:
     if "polygon" in single_area:
         # Takes form "x,y x,y x,y" but with newlines that need to be removed
         polygon_str = single_area["polygon"].replace("\n", "").split()
-        polygon_list = [list(map(float, coord.split(","))) for coord in polygon_str] # noqa
+        polygon_list = [
+            list(map(float, coord.split(","))) for coord in polygon_str
+        ]  # noqa
         return ensure_counter_clockwise(polygon_list)
 
     return []
@@ -179,14 +181,14 @@ def preprocess_alert(xml: str) -> str:
     return re.sub(r"<(/?)cap:(\w+)", r"<\1\2", xml)
 
 
-def to_geojson(xml: str) -> str:
+def to_geojson(xml: str) -> dict:
     """Takes the CAP alert XML and converts it to a GeoJSON.
 
     Args:
         xml (str): The CAP XML string.
 
     Returns:
-        str: The final GeoJSON object stringified.
+        str: The final GeoJSON object.
     """
     processed_xml = preprocess_alert(xml)
 
@@ -210,19 +212,16 @@ def to_geojson(xml: str) -> str:
 
     alert_geometry = get_geometry(area)
 
-    result = json.dumps(
-        {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "properties": alert_properties,
-                    "geometry": alert_geometry,
-                }
-            ],
-        },
-        indent=4,
-    )
+    result = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": alert_properties,
+                "geometry": alert_geometry,
+            }
+        ],
+    }
 
     try:
         geojson.loads(result)

--- a/tests/test_cap2geojson.py
+++ b/tests/test_cap2geojson.py
@@ -43,7 +43,7 @@ def sc_alert():
 
 def test_to_geojson(sc_alert):
     with open("tests/output/sc.geojson", "r") as f:
-        expected = f.read()
+        expected = json.load(f)
 
     assert to_geojson(sc_alert) == expected
 

--- a/tests/test_cap2geojson.py
+++ b/tests/test_cap2geojson.py
@@ -45,7 +45,12 @@ def test_to_geojson(sc_alert):
     with open("tests/output/sc.geojson", "r") as f:
         expected = json.load(f)
 
-    assert to_geojson(sc_alert) == expected
+    actual = to_geojson(sc_alert)
+
+    print("Expected:", expected)
+    print("Actual:", actual)
+
+    assert actual == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
Although the output in the `cli.py` should be a string written to a file, the API output should be a dict.