### PR TITLE
Fix: CAP alerts use y,x coordinates, ensure they are converted to x,y

### DIFF
--- a/src/cap2geojson/__init__.py
+++ b/src/cap2geojson/__init__.py
@@ -23,7 +23,7 @@ import logging
 
 from .convert import to_geojson
 
-__version__ = "0.1.0-dev2"
+__version__ = "0.1.0-dev3"
 
 logging.basicConfig(
     level=logging.INFO,

--- a/src/cap2geojson/convert.py
+++ b/src/cap2geojson/convert.py
@@ -127,18 +127,19 @@ def get_polygon_coordinates(single_area: dict) -> list:
         list: The list of polygon coordinate pairs.
     """
     if "circle" in single_area:
-        # Takes form "x,y r"
+        # Takes form "y,x r"
         centre, radius = single_area["circle"].split(" ")
         radius = float(radius)
-        x_centre, y_centre = map(float, centre.split(","))
+        y_centre, x_centre = map(float, centre.split(","))
         # Estimate the circle coordinates with n=100 points
         return list(get_circle_coords(x_centre, y_centre, radius, 100))
 
     if "polygon" in single_area:
-        # Takes form "x,y x,y x,y" but with newlines that need to be removed
+        # Takes form "y,x y,x y,x". So, split on whitespace, then comma, and
+        # reverse the order of the coordinates to be (x, y).
         polygon_str = single_area["polygon"].replace("\n", "").split()
         polygon_list = [
-            list(map(float, coord.split(","))) for coord in polygon_str
+            list(map(float, coord.split(",")[::-1])) for coord in polygon_str
         ]  # noqa
         return ensure_counter_clockwise(polygon_list)
 

--- a/tests/output/sc.geojson
+++ b/tests/output/sc.geojson
@@ -1,94 +1,94 @@
 {
     "type": "FeatureCollection",
     "features": [
-        {
-            "type": "Feature",
-            "properties": {
-                "identifier": "urn:oid:2.49.0.0.690.0.2024.5.19.13.18.0",
-                "sender": "info@meteo.gov.sc",
-                "sent": "2024-05-19T17:18:00+04:00",
-                "status": "Actual",
-                "msgType": "Alert",
-                "scope": "Public",
-                "category": "Met",
-                "event": "Strong Winds",
-                "urgency": "Immediate",
-                "severity": "Moderate",
-                "certainty": "Observed",
-                "effective": "2024-05-19T17:30:00+04:00",
-                "onset": "2024-05-19T17:30:00+04:00",
-                "expires": "2024-05-19T23:30:00+04:00",
-                "senderName": "Seychelles Meteorological Authority",
-                "headline": "Moderate to strong south-easterly winds over Aldabra area",
-                "description": "Moderate to strong south-easterly winds over Aldabra area associated with a severe tropical storm Ialy on 19th May 2024 from 5pm to 11pm",
-                "instruction": "Beware of strong south-easterly winds of 40km/hr gusting to 60km/hr causing rough seas. Mariners are advised to take extra precautions when navigating these areas",
-                "web": "https://www.meteo.sc/alerts/severe-tropical-storm-ialy-is-expected-to-cause-moderate-to-strong-south-easterly-winds-over-aldabra-area-on-19th-may-2024/",
-                "contact": "info@meteo.gov.sc",
-                "areaDesc": "Aldabra area"
-            },
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [
-                            -9.186965,
-                            46.078276
-                        ],
-                        [
-                            -9.121416,
-                            46.362825
-                        ],
-                        [
-                            -9.140146,
-                            46.533555
-                        ],
-                        [
-                            -9.186965,
-                            46.694799
-                        ],
-                        [
-                            -9.327387,
-                            46.742224
-                        ],
-                        [
-                            -9.467752,
-                            46.770679
-                        ],
-                        [
-                            -9.692216,
-                            46.770679
-                        ],
-                        [
-                            -9.953902,
-                            46.694799
-                        ],
-                        [
-                            -10.000609,
-                            46.42922
-                        ],
-                        [
-                            -9.897844,
-                            46.249006
-                        ],
-                        [
-                            -9.748309,
-                            46.116216
-                        ],
-                        [
-                            -9.57065,
-                            45.983427
-                        ],
-                        [
-                            -9.336746,
-                            45.936002
-                        ],
-                        [
-                            -9.186965,
-                            46.078276
-                        ]
-                    ]
-                ]
-            }
+      {
+        "type": "Feature",
+        "properties": {
+          "identifier": "urn:oid:2.49.0.0.690.0.2024.5.19.13.18.0",
+          "sender": "info@meteo.gov.sc",
+          "sent": "2024-05-19T17:18:00+04:00",
+          "status": "Actual",
+          "msgType": "Alert",
+          "scope": "Public",
+          "category": "Met",
+          "event": "Strong Winds",
+          "urgency": "Immediate",
+          "severity": "Moderate",
+          "certainty": "Observed",
+          "effective": "2024-05-19T17:30:00+04:00",
+          "onset": "2024-05-19T17:30:00+04:00",
+          "expires": "2024-05-19T23:30:00+04:00",
+          "senderName": "Seychelles Meteorological Authority",
+          "headline": "Moderate to strong south-easterly winds over Aldabra area",
+          "description": "Moderate to strong south-easterly winds over Aldabra area associated with a severe tropical storm Ialy on 19th May 2024 from 5pm to 11pm",
+          "instruction": "Beware of strong south-easterly winds of 40km/hr gusting to 60km/hr causing rough seas. Mariners are advised to take extra precautions when navigating these areas",
+          "web": "https://www.meteo.sc/alerts/severe-tropical-storm-ialy-is-expected-to-cause-moderate-to-strong-south-easterly-winds-over-aldabra-area-on-19th-may-2024/",
+          "contact": "info@meteo.gov.sc",
+          "areaDesc": "Aldabra area"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                46.078276,
+                -9.186965
+              ],
+              [
+                45.936002,
+                -9.336746
+              ],
+              [
+                45.983427,
+                -9.57065
+              ],
+              [
+                46.116216,
+                -9.748309
+              ],
+              [
+                46.249006,
+                -9.897844
+              ],
+              [
+                46.42922,
+                -10.000609
+              ],
+              [
+                46.694799,
+                -9.953902
+              ],
+              [
+                46.770679,
+                -9.692216
+              ],
+              [
+                46.770679,
+                -9.467752
+              ],
+              [
+                46.742224,
+                -9.327387
+              ],
+              [
+                46.694799,
+                -9.186965
+              ],
+              [
+                46.533555,
+                -9.140146
+              ],
+              [
+                46.362825,
+                -9.121416
+              ],
+              [
+                46.078276,
+                -9.186965
+              ]
+            ]
+          ]
         }
+      }
     ]
-}
+  }

--- a/tests/test_cap2geojson.py
+++ b/tests/test_cap2geojson.py
@@ -83,7 +83,7 @@ def test_circle_coords(circle):
 @pytest.fixture
 def circle_area():
     return {
-        "circle": "5.0,3.0 7.0",
+        "circle": "3.0,5.0 7.0",
     }
 
 


### PR DESCRIPTION
The coordinates should be the correct way round in GeoJSON format. The order was previously preserved, and this branch corrects that.